### PR TITLE
Handling when content is not html formatted

### DIFF
--- a/server.js
+++ b/server.js
@@ -34,7 +34,13 @@ export const sendEmail = async ({ to, subject, content, from: fromParam }) => {
 };
 
 Email.customTransport = options => {
-  const { to, subject, html } = options;
+  const { to, subject } = options;
+  let { html } = options;
+
+  if (!html) {
+    html = options.text;
+  }
+  
   const overrideOptions = Email.overrideOptionsBeforeSend
     ? Email.overrideOptionsBeforeSend(options)
     : {};


### PR DESCRIPTION
When content is text (ex. using `Accounts.sendVerificationEmail` default template) it won't be any errors caused by  template's structure.